### PR TITLE
Add automatic HQ sync and warehouse query

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ cd log430lab1
    podman-compose build
    ```
 
-2. Start the database in detached mode:
+2. Start the databases in detached mode (local store and HQ):
 
    ```bash
-   podman-compose up -d db
+   podman-compose up -d db hqdb
    ```
 
 3. Run the client (CLI) interactively (inherit tty and stdin settings from service):
@@ -42,7 +42,9 @@ cd log430lab1
    podman-compose run --rm app
    ```
 
-This ensures the database runs in the background while you interact with the POS CLI.
+This ensures both databases run in the background while you interact with the POS CLI.
+The compose file already sets `HQ_DATABASE_URL` so the application can
+synchronize with the HQ database and generate consolidated reports.
 
 ## Stopping Services
 
@@ -88,6 +90,11 @@ After starting the DB and running `podman-compose run --rm app`, you will see a 
 4. Record sale
 5. Return sale
 6. Stock report
+7. Sales report
+8. Replenish from warehouse
+9. Dashboard
+10. HQ sales report
+11. HQ stock report
 0. Exit
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,18 +5,31 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
-      POSTGRES_DB: posdb
+      POSTGRES_DB: posdb_local
     ports:
       - "5432:5432"
     volumes:
       - ./db_data:/var/lib/postgresql/data
 
+  hqdb:
+    image: docker.io/library/postgres:13
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: posdb_hq
+    ports:
+      - "5433:5432"
+    volumes:
+      - ./hq_db_data:/var/lib/postgresql/data
+
   app:
     build: .
     environment:
-      DATABASE_URL: postgresql+psycopg2://postgres:password@db:5432/posdb
+      DATABASE_URL: postgresql+psycopg2://postgres:password@db:5432/posdb_local
+      HQ_DATABASE_URL: postgresql+psycopg2://postgres:password@hqdb:5432/posdb_hq
     depends_on:
       - db
+      - hqdb
     volumes:
       - ./src:/app/src
     stdin_open: true  # keep stdin open for interactive console

--- a/docs/UML/deployment_view.puml
+++ b/docs/UML/deployment_view.puml
@@ -1,13 +1,17 @@
 @startuml deployment_view
-title Deployment View - 2-Tier Architecture
+title Deployment View - Local/HQ Databases
 
 node "App Container" as App {
     component "POS CLI" as POS_CLI
 }
 
-node "DB Container" as DB {
-    database "PostgreSQL" as POSTGRES_DB
+node "Local DB" as Local {
+    database "PostgreSQL" as DB_LOCAL
+}
+node "HQ DB" as HQ {
+    database "PostgreSQL" as DB_HQ
 }
 
-POS_CLI --> POSTGRES_DB : SQLAlchemy over TCP
+POS_CLI --> DB_LOCAL : ORM calls
+POS_CLI --> DB_HQ : sync
 @enduml

--- a/docs/UML/logical_view_class_diagram.puml
+++ b/docs/UML/logical_view_class_diagram.puml
@@ -22,7 +22,22 @@ class SaleItem {
   - price: Float
   + __repr__(): String
 }
+class Store {
+  - id: Integer
+  - name: String
+  - location: String
+  + __repr__(): String
+}
+class CentralStock {
+  - id: Integer
+  - product_id: Integer
+  - quantity: Integer
+  + __repr__(): String
+}
 
 Product "1" <-- "*" SaleItem : contains
 Sale "1" <-- "*" SaleItem : items
+Store "1" <-- "*" Product : manages
+Store "1" <-- "*" Sale : records
+Product "1" <-- "*" CentralStock : stocked in
 @enduml

--- a/docs/UML/sequence_view.puml
+++ b/docs/UML/sequence_view.puml
@@ -2,13 +2,15 @@
 title Sequence Diagram - POS CLI Operations
 actor User
 participant "POS CLI" as CLI
-database "PostgreSQL DB" as DB
+database "Local DB" as DB
+database "HQ DB" as HQ
 
 User -> CLI : select "Record sale"
 CLI -> DB : INSERT INTO sales...
 DB --> CLI : sale_id
 CLI -> DB : INSERT INTO sale_items...
 DB --> CLI : success
+CLI -> HQ : sync new sale
 CLI --> User : "Sale recorded"
 
 User -> CLI : select "Stock report"

--- a/src/cli.py
+++ b/src/cli.py
@@ -18,6 +18,11 @@ def main():
         '4': ('Record sale', cli_views.record_sale),
         '5': ('Return sale', cli_views.return_sale),
         '6': ('Stock report', cli_views.show_stock_report),
+        '7': ('Sales report', cli_views.sales_report),
+        '8': ('Replenish from warehouse', cli_views.handle_replenishment),
+        '9': ('Dashboard', cli_views.show_dashboard),
+        '10': ('HQ sales report', cli_views.hq_sales_report),
+        '11': ('HQ stock report', cli_views.hq_stock_report),
         '0': ('Exit', lambda: sys.exit(0)),
     }
 

--- a/src/controllers/__init__.py
+++ b/src/controllers/__init__.py
@@ -1,26 +1,33 @@
 """Business logic layer for POS operations."""
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 
-from src.db import SessionLocal
-from src.models import Product, Sale, SaleItem
+from sqlalchemy import func
+
+from src.db import HQSession, SessionLocal
+from src.models import CentralStock, Product, Sale, SaleItem, Store
 
 
-def add_product(name: str, price: float, category: str) -> Product:
-    """Create a new product and persist it."""
+def add_product(name: str, price: float, category: str, store_id: int) -> Product:
+    """Create a new product for a given store and sync to HQ."""
+    # ensure we have latest data from HQ
+    sync_from_hq()
     session = SessionLocal()
     try:
-        prod = Product(name=name, price=price, category=category)
+        prod = Product(name=name, price=price, category=category, store_id=store_id)
         session.add(prod)
         session.commit()
         session.refresh(prod)
-        return prod
     finally:
         session.close()
+    # push changes to HQ database
+    sync_to_hq()
+    return prod
 
 
 def update_stock(product_id: int, quantity: int) -> Optional[Product]:
-    """Update stock quantity for a product."""
+    """Update stock quantity for a product and sync."""
+    sync_from_hq()
     session = SessionLocal()
     try:
         prod = session.get(Product, product_id)
@@ -29,48 +36,54 @@ def update_stock(product_id: int, quantity: int) -> Optional[Product]:
         prod.stock = quantity  # type: ignore[attr-defined]
         session.commit()
         session.refresh(prod)
-        return prod
     finally:
         session.close()
+    sync_to_hq()
+    return prod
 
 
-def search_products(term: str) -> List[Product]:
-    """Return products matching the search term."""
+def search_products(term: str, store_id: int | None = None) -> List[Product]:
+    """Return products matching the search term for a store."""
     session = SessionLocal()
     try:
-        results = (
-            session.query(Product)
-            .filter(
-                (Product.name.ilike(f"%{term}%"))
-                | (Product.category.ilike(f"%{term}%"))
-            )
-            .all()
+        query = session.query(Product).filter(
+            (Product.name.ilike(f"%{term}%")) | (Product.category.ilike(f"%{term}%"))
         )
-        return results
+        if store_id is not None:
+            query = query.filter(Product.store_id == store_id)
+        return query.all()
     finally:
         session.close()
 
 
 def record_sale(product_id: int, quantity: int) -> Optional[Sale]:
-    """Record a sale transaction if stock allows."""
+    """Record a sale transaction if stock allows and sync."""
+    sync_from_hq()
     session = SessionLocal()
     try:
         prod = session.get(Product, product_id)
         if prod is None or prod.stock < quantity:  # type: ignore[operator]
             return None
-        sale = Sale()
-        _item = SaleItem(sale=sale, product=prod, quantity=quantity, price=prod.price)
+        sale = Sale(store_id=prod.store_id)
+        _item = SaleItem(
+            sale=sale,
+            product=prod,
+            quantity=quantity,
+            price=prod.price,
+        )
         prod.stock -= quantity  # type: ignore[attr-defined]
         session.add(sale)
         session.commit()
         session.refresh(sale)
-        return sale
     finally:
         session.close()
+    sync_to_hq()
+    return sale
 
 
 def return_sale(sale_id: int) -> bool:
-    """Cancel a sale and restock items."""
+    """Cancel a sale, restock items and sync."""
+    sync_from_hq()
     session = SessionLocal()
     try:
         sale = session.get(Sale, sale_id)
@@ -82,15 +95,206 @@ def return_sale(sale_id: int) -> bool:
                 prod.stock += item.quantity  # type: ignore[attr-defined]
         session.delete(sale)
         session.commit()
-        return True
+    finally:
+        session.close()
+    sync_to_hq()
+    return True
+
+
+def get_stock_report(store_id: int | None = None) -> List[Product]:
+    """Return a list of products for reporting for a given store."""
+    session = SessionLocal()
+    try:
+        query = session.query(Product)
+        if store_id is not None:
+            query = query.filter(Product.store_id == store_id)
+        return query.all()
     finally:
         session.close()
 
 
-def get_stock_report() -> List[Product]:
-    """Return a list of all products for reporting."""
+def generate_sales_report() -> Dict[str, List]:
+    """Return consolidated sales report data for all stores."""
     session = SessionLocal()
     try:
-        return session.query(Product).all()
+        return _generate_report_for_session(session)
+    finally:
+        session.close()
+
+
+def request_replenishment(store_id: int, product_id: int, quantity: int) -> bool:
+    """Transfer stock from the central warehouse to a store if available."""
+    sync_from_hq()
+    session = SessionLocal()
+    try:
+        central = (
+            session.query(CentralStock)
+            .filter(CentralStock.product_id == product_id)
+            .first()
+        )
+        product = session.query(Product).filter(
+            Product.id == product_id, Product.store_id == store_id
+        ).first()
+        if central is None or product is None or central.quantity < quantity:
+            return False
+
+        central.quantity -= quantity
+        product.stock += quantity  # type: ignore[attr-defined]
+        session.commit()
+    finally:
+        session.close()
+    sync_to_hq()
+    return True
+
+
+def get_dashboard_metrics() -> Dict[str, List]:
+    """Return high level performance indicators for all stores."""
+    session = SessionLocal()
+    try:
+        # Revenue per store
+        revenue = (
+            session.query(
+                Store.name,
+                func.sum(SaleItem.quantity * SaleItem.price).label("revenue"),
+            )
+            .join(Sale)
+            .join(SaleItem)
+            .group_by(Store.name)
+            .all()
+        )
+
+        # Products with zero stock trigger an alert
+        out_of_stock = (
+            session.query(Product.name, Store.name)
+            .join(Store)
+            .filter(Product.stock <= 0)
+            .all()
+        )
+
+        # Very high stock could indicate overstock
+        overstock = (
+            session.query(Product.name, Store.name, Product.stock)
+            .join(Store)
+            .filter(Product.stock > 100)
+            .all()
+        )
+
+        # Weekly revenue trends per store
+        weekly = (
+            session.query(
+                func.date_trunc("week", Sale.timestamp).label("week"),
+                Store.name,
+                func.sum(SaleItem.quantity * SaleItem.price).label("revenue"),
+            )
+            .join(Store)
+            .join(SaleItem)
+            .group_by("week", Store.name)
+            .order_by("week")
+            .all()
+        )
+
+        return {
+            "revenue": revenue,
+            "out_of_stock": out_of_stock,
+            "overstock": overstock,
+            "weekly": weekly,
+        }
+    finally:
+        session.close()
+
+
+def sync_to_hq() -> bool:
+    """Push local data to the HQ database."""
+    if HQSession is SessionLocal:
+        return False
+    local = SessionLocal()
+    hq = HQSession()
+    try:
+        for model in (Store, Product, Sale, SaleItem, CentralStock):
+            for obj in local.query(model).all():
+                hq.merge(obj)
+        hq.commit()
+        return True
+    finally:
+        local.close()
+        hq.close()
+
+
+def sync_from_hq() -> bool:
+    """Pull data from the HQ database into the local store."""
+    if HQSession is SessionLocal:
+        return False
+    local = SessionLocal()
+    hq = HQSession()
+    try:
+        for model in (Store, Product, CentralStock):
+            for obj in hq.query(model).all():
+                local.merge(obj)
+        for sale in hq.query(Sale).all():
+            local.merge(sale)
+            for item in sale.items:
+                local.merge(item)
+        local.commit()
+        return True
+    finally:
+        local.close()
+        hq.close()
+
+
+def generate_hq_sales_report() -> Dict[str, List]:
+    """Generate a sales report using the HQ database."""
+    if HQSession is SessionLocal:
+        return generate_sales_report()
+    session = HQSession()
+    try:
+        return _generate_report_for_session(session)
+    finally:
+        session.close()
+
+
+def _generate_report_for_session(session) -> Dict[str, List]:
+    """Helper to generate sales report using a provided session."""
+    store_data = []
+    for store in session.query(Store).all():
+        revenue = (
+            session.query(func.sum(SaleItem.quantity * SaleItem.price))
+            .join(Sale)
+            .filter(Sale.store_id == store.id)
+            .scalar()
+            or 0.0
+        )
+        store_data.append({"store": store.name, "revenue": float(revenue)})
+
+    top_products = (
+        session.query(
+            Product.name,
+            func.sum(SaleItem.quantity).label("qty"),
+        )
+        .join(SaleItem, SaleItem.product_id == Product.id)
+        .group_by(Product.name)
+        .order_by(func.sum(SaleItem.quantity).desc())
+        .limit(5)
+        .all()
+    )
+
+    stock = (
+        session.query(Product.name, Product.stock, Store.name)
+        .join(Store, Product.store_id == Store.id)
+        .all()
+    )
+
+    return {"stores": store_data, "top_products": top_products, "stock": stock}
+
+
+def get_hq_stock() -> List[tuple[str, int]]:
+    """Return the current HQ warehouse stock."""
+    session = HQSession()
+    try:
+        return (
+            session.query(Product.name, CentralStock.quantity)
+            .join(CentralStock, CentralStock.product_id == Product.id)
+            .order_by(Product.name)
+            .all()
+        )
     finally:
         session.close()

--- a/src/db.py
+++ b/src/db.py
@@ -13,7 +13,20 @@ DATABASE_URL = os.getenv(
 )
 
 engine = create_engine(DATABASE_URL, echo=False, future=True)
-SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+SessionLocal = sessionmaker(
+    bind=engine, autoflush=False, autocommit=False, future=True
+)
+
+# Optional second engine used to represent the HQ database. If no separate HQ
+# database URL is provided, it defaults to the same engine as the local store.
+HQ_DATABASE_URL = os.getenv('HQ_DATABASE_URL')
+if HQ_DATABASE_URL:
+    hq_engine = create_engine(HQ_DATABASE_URL, echo=False, future=True)
+    HQSession = sessionmaker(
+        bind=hq_engine, autoflush=False, autocommit=False, future=True
+    )
+else:
+    HQSession = SessionLocal
 Base = declarative_base()
 
 def init_db():
@@ -21,3 +34,5 @@ def init_db():
     # Dynamically import models to register them with metadata
     __import__('src.models')
     Base.metadata.create_all(bind=engine)
+    if HQ_DATABASE_URL:
+        Base.metadata.create_all(bind=hq_engine)

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -11,6 +11,37 @@ from sqlalchemy.orm import relationship
 from src.db import Base
 
 
+class Store(Base):
+    """Represents a physical store location."""
+
+    __tablename__ = "stores"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, nullable=False)
+    location = Column(String, nullable=True)
+
+    products = relationship("Product", back_populates="store")
+    sales = relationship("Sale", back_populates="store")
+
+    def __repr__(self) -> str:  # pragma: no cover - simple representation
+        return f"<Store {self.name}>"
+
+
+class CentralStock(Base):
+    """Represents stock kept at the logistics center."""
+
+    __tablename__ = "central_stock"
+
+    id = Column(Integer, primary_key=True, index=True)
+    product_id = Column(Integer, ForeignKey("products.id"))
+    quantity = Column(Integer, default=0)
+
+    product = relationship("Product")
+
+    def __repr__(self) -> str:  # pragma: no cover - simple representation
+        return f"<CentralStock product={self.product_id} qty={self.quantity}>"
+
+
 class Product(Base):
     """Represents a product in the inventory."""
 
@@ -21,6 +52,9 @@ class Product(Base):
     category = Column(String, index=True, nullable=True)
     price = Column(Float, nullable=False)
     stock = Column(Integer, default=0)
+    store_id = Column(Integer, ForeignKey("stores.id"), nullable=True)
+
+    store = relationship("Store", back_populates="products")
 
     def __repr__(self):
         return f"<Product {self.name}>"
@@ -33,7 +67,10 @@ class Sale(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     timestamp = Column(DateTime, default=datetime.datetime.utcnow)
+    store_id = Column(Integer, ForeignKey("stores.id"), nullable=True)
     items = relationship("SaleItem", back_populates="sale", cascade="all, delete")
+
+    store = relationship("Store", back_populates="sales")
 
     def __repr__(self):
         return f"<Sale {self.id}>"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 """Module tests for ORM model repr methods."""
 
-from src.models import Product, Sale, SaleItem
+from src.models import Product, Sale, SaleItem, Store, CentralStock
 
 
 def test_product_repr():
@@ -16,3 +16,11 @@ def test_sale_and_saleitem_repr():
     assert repr(s).startswith("<Sale ") and repr(s).endswith(">")
     item = SaleItem(sale_id=1, product_id=2, quantity=3, price=4.0)
     assert "sale=1" in repr(item) and "product=2" in repr(item)
+
+
+def test_store_and_centralstock_repr():
+    """Store and CentralStock __repr__ outputs."""
+    store = Store(name="Main", location="HQ")
+    assert "<Store Main>" == repr(store)
+    cs = CentralStock(product_id=1, quantity=5)
+    assert "product=1" in repr(cs) and "qty=5" in repr(cs)


### PR DESCRIPTION
## Summary
- trigger sync with HQ whenever stock or sales change
- provide a view to inspect HQ warehouse stock
- simplify CLI menu and update documentation
- refresh UML diagrams to show local/HQ DBs

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684309583ea48321b160b32d0cfb7257